### PR TITLE
Raise dependency to TYPO3 9.x

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,7 +15,7 @@ $EM_CONF[$_EXTKEY] = [
     ],
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.0-9.9.99',
+            'typo3' => '9.0.0-9.9.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
This package use classes, wich are only available in newer TYPO3 versions fx. HtmlResponse