### PR TITLE
[BUGFIX] Use correct view helper to get icon

### DIFF
--- a/Resources/Private/Templates/Index.html
+++ b/Resources/Private/Templates/Index.html
@@ -167,25 +167,25 @@
 		</li>
 		<li class="nav-item dropdown">
 			<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-				<f:image src="/typo3/sysext/core/Resources/Public/Icons/T3Icons/actions/actions-view.svg"/>
+				<core:icon identifier="actions-view" />
 				<f:translate key="LLL:EXT:digital_asset_management/Resources/Private/Language/locallang_mod.xlf:dam.labels.nav.view"/>
 			</a>
 			<div class="dropdown-menu" aria-labelledby="navbarDropdown">
 				<div class="dropdown-item view-action" data-action="view-list">
-					<f:image class="ui-icon" src="/typo3/sysext/core/Resources/Public/Icons/T3Icons/content/content-menu-thumbnail.svg"/>
+					<core:icon identifier="content-menu-thumbnail" />
 					<f:translate key="LLL:EXT:digital_asset_management/Resources/Private/Language/locallang_mod.xlf:dam.labels.nav.view.list"/></div>
 				<div class="dropdown-item view-action" data-action="view-symbols">
-					<f:image src="/typo3/sysext/core/Resources/Public/Icons/T3Icons/content/content-image.svg"/>
+					<core:icon identifier="content-image" />
 					<f:translate key="LLL:EXT:digital_asset_management/Resources/Private/Language/locallang_mod.xlf:dam.labels.nav.view.symbols"/></div>
 				<div class="dropdown-divider"></div>
 				<div class="dropdown-item view-action" data-action="view-photo">
-					<f:image src="/typo3/sysext/core/Resources/Public/Icons/T3Icons/content/content-menu-thumbnail.svg"/>
+					<core:icon identifier="content-menu-thumbnail" />
 					<f:translate key="LLL:EXT:digital_asset_management/Resources/Private/Language/locallang_mod.xlf:dam.labels.nav.view.photos"/></div>
 			</div>
 		</li>
 		<li class="nav-item">
 			<div class="ajax-action nav-link disabled" data-action="reindexStorage" data-parameter="#current#">
-				<f:image src="/typo3/sysext/core/Resources/Public/Icons/T3Icons/actions/actions-refresh.svg"/>
+				<core:icon identifier="actions-refresh" />
 			</div>
 		</li>
 	</ul>


### PR DESCRIPTION
This change uses the `core:icon` view helper to render the icons. This is necessary to find the real bottlenecks in FAL.